### PR TITLE
Added "extern C" block for C++ compilation

### DIFF
--- a/include/trlib.h.in
+++ b/include/trlib.h.in
@@ -25,6 +25,10 @@
 #ifndef TRLIB_H
 #define TRLIB_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdio.h>
 #include "trlib/trlib_types.h"
 #include "trlib/trlib_eigen_inverse.h"
@@ -32,5 +36,9 @@
 #include "trlib/trlib_leftmost.h"
 #include "trlib/trlib_quadratic_zero.h"
 #include "trlib/trlib_tri_factor.h"
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
This patch enables the use of trlib directly from C++ (enabling C-style name mangling).  Please bump the version if you accept the patch :)