### PR TITLE
Added version information to exported targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(CMakePackageConfigHelpers)
+
 find_package(BLAS REQUIRED)
 find_package(LAPACK REQUIRED)
 
@@ -54,6 +56,17 @@ install ( FILES ${CMAKE_SOURCE_DIR}/src/trlib_krylov.c
                 ${CMAKE_SOURCE_DIR}/src/trlib_quadratic_zero.c
                 ${CMAKE_BINARY_DIR}/src/trlib_private.h
                 DESTINATION "share/trlib/src" )
+
+write_basic_package_version_file(
+  "${CMAKE_BINARY_DIR}/trlib-config-version.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY ExactVersion
+)
+
+install(
+  FILES "${CMAKE_BINARY_DIR}/trlib-config-version.cmake"
+  DESTINATION "lib/cmake/trlib"
+)
 
 #find_package(HDF5)
 #find_package(SuiteSparse OPTIONAL_COMPONENTS CHOLMOD)


### PR DESCRIPTION
This makes the version available to downstream projects using trlib via a cmake import, enabling users to find a suitable version of trlib via 

    find_package(trlib <Version> REQUIRED)

and make the version available via the trlib_VERSION variable.

Note that I set the compatibility to require the exact same verion, maybe you want to loosen that requirement to the same major / minor version instead...