### PR TITLE
Add LANGUAGES C option to project CMake call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.1)
-project (TRLIB VERSION 0.4)
+project (TRLIB VERSION 0.4 LANGUAGES C)
 
 set(PROJECT_DESCRIPTION "Trust Region Subproblem Solver Library")
 


### PR DESCRIPTION
As trlib is a pure C library, we can explicitly specify this in CMake. If `LANGUAGES` is not specified, it defaults to `C CXX` (see https://cmake.org/cmake/help/latest/command/project.html), requiring a C++ compiler for configuring the project, even if that is not actually needed. This changes ensures that a C++ compiler is not required when building trlib.