### PR TITLE
Update minimum cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.13)
 project (TRLIB VERSION 0.4 LANGUAGES C)
 
 set(PROJECT_DESCRIPTION "Trust Region Subproblem Solver Library")


### PR DESCRIPTION
I am getting the error

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```
 Since version 3.13 of cmake was released in late 2018 and the package seems to build fine with later version I suggest to update the dependency.