### PR TITLE
Python 3.12 support

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(PY_VER "2" "3")
             if(PY_VER EQUAL "2")
                 execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_vars()['SO'])" OUTPUT_VARIABLE PY_SO)
             elseif(PY_VER EQUAL "3")
-                execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import distutils.sysconfig; print(distutils.sysconfig.get_config_vars()['EXT_SUFFIX'])" OUTPUT_VARIABLE PY_SO)
+                execute_process(COMMAND ${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_config_vars()['EXT_SUFFIX'])" OUTPUT_VARIABLE PY_SO)
             endif(PY_VER EQUAL "2")
             string(STRIP ${PY_SO} PY_SO)
 


### PR DESCRIPTION
Hi,

In python 3.12, `distutils` was removed. `EXT_SUFFIX` is still available in `sysconfig`. 

ref. https://peps.python.org/pep-0632/#migration-advice